### PR TITLE
Potential fix for code scanning alert no. 1183: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/MANSPIDER-UP/security/code-scanning/1183](https://github.com/deadjdona/MANSPIDER-UP/security/code-scanning/1183)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only needs to read the repository contents to run `pylint`, we will set `contents: read` as the minimal required permission. This ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
